### PR TITLE
Wait login page loads completely before the next action

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var login = exports.login = function(email, password){
       .type('#session_key-login', email)
       .type('#session_password-login', password)
       .click('#btn-primary')
-      .wait('#main-search-box');
+      .wait();
   };
 };
 


### PR DESCRIPTION
Sometimes, the search box can't be found if you don't wait the page load completely
